### PR TITLE
Fix transcription error: m’dear -> my dear

### DIFF
--- a/src/epub/text/moll-flanders.xhtml
+++ b/src/epub/text/moll-flanders.xhtml
@@ -378,7 +378,7 @@
 			<p>In short, we were married, and very happily married on my side, I assure you, as to the man; for he was the best-humoured man that every woman had, but his circumstances were not so good as I imagined, as, on the other hand, he had not bettered himself by marrying so much as he expected.</p>
 			<p>When we were married, I was shrewdly put to it to bring him that little stock I had, and to let him see it was no more; but there was a necessity for it, so I took my opportunity one day when we were alone, to enter into a short dialogue with him about it. “My dear,” said I, “we have been married a fortnight; is it not time to let you know whether you have got a wife with something or with nothing?” “Your own time for that, my dear,” says he; “I am satisfied that I have got the wife I love; I have not troubled you much,” says he, “with my inquiry after it.”</p>
 			<p>“That’s true,” says I, “but I have a great difficulty upon me about it, which I scarce know how to manage.”</p>
-			<p>“What’s that, m’dear?” says he.</p>
+			<p>“What’s that, my dear?” says he.</p>
 			<p>“Why,” says I, “ ’tis a little hard upon me, and ’tis harder upon you. I am told that Captain ⸻” (meaning my friend’s husband) “has told you I had a great deal more money than I ever pretended to have, and I am sure I never employed him to do so.”</p>
 			<p>“Well,” says he, “Captain ⸻ may have told me so, but what then? If you have not so much, that may lie at his door, but you never told me what you had, so I have no reason to blame you if you have nothing at all.”</p>
 			<p>“That’s is so just,” said I, “and so generous, that it makes my having but a little a double affliction to me.”</p>


### PR DESCRIPTION
Sorry, I fixed this the wrong way in a previous commit:

https://github.com/standardebooks/daniel-defoe_moll-flanders/commit/5eb27715a3a55e51520c2acfdf6d47e05a4ba737

I triple-checked, and all three scans I checked have "my dear."

(I noticed my mistake while reporting errors to PG.)